### PR TITLE
Fix underground parking not being excluded

### DIFF
--- a/src/overpass/overpass.ts
+++ b/src/overpass/overpass.ts
@@ -9,7 +9,7 @@ export const overpassQuery = async (bounds: LngLatBounds) => {
   const body = `
   [out:json][bbox:${bbox}];
   (way[amenity=parking]${restrictTags
-    .map((tag: string) => `[amenity!~"${tag}"]`)
+    .map((tag: string) => `[parking!~"${tag}"]`)
     .join("")};)->.x1;nwr.x1->.result;
   (.result; - .done;)->.result;
   .result out meta geom qt;


### PR DESCRIPTION
I noticed in Philadelphia that two underground parking lots were showing up that should have been excluded.

Looking at openstreetbrowser.org it looks like the attribute that needs to be excluded is "parking" with the value "underground" but the current code instead excludes "amenity: underground". 

I tried the fix (that's in this pull request) and it correctly removed the two underground parking lots, fixing my issue. 