### PR TITLE
Fix map stuttering on movement

### DIFF
--- a/src/components/CheckBox.tsx
+++ b/src/components/CheckBox.tsx
@@ -17,6 +17,7 @@ export const CheckBox = ({
       type="checkbox"
       className="mb-3 cursor-pointer"
       checked={isChecked}
+      readOnly
     />
     <label className="text-blue-500 m-3 select-none cursor-pointer">
       {children}

--- a/src/pages/[latitude]/[longitude]/[zoom]/index.tsx
+++ b/src/pages/[latitude]/[longitude]/[zoom]/index.tsx
@@ -8,6 +8,7 @@ import { analyzeParking } from "@/utils/analyzeParking";
 import { validateViewport } from "@/utils/validateViewport";
 import { defaultViewport } from "@/config/defaults";
 import { MainMap } from "@/components/MainMap";
+import { MapRef } from "react-map-gl";
 
 export const MainPage = () => {
   const [bounds, setBounds] = useState<LngLatBounds>();
@@ -23,28 +24,36 @@ export const MainPage = () => {
   const [showInfoModal, setShowInfoModal] = useState(false);
   const [viewport, setViewport] = useState(defaultViewport);
   const [error, setError] = useState(false);
+  const [initialized, setInitialized] = useState(false);
 
-  const mapRef = useRef<any>(null);
+  const mapRef = useRef<MapRef>(null);
 
   const router = useRouter();
   const { latitude, longitude, zoom } = router.query;
 
   useEffect(() => {
     const isValidViewport = validateViewport(latitude, longitude, zoom);
+    const lat = Number(latitude);
+    const lng = Number(longitude);
+    const z = Number(zoom);
 
     if (isValidViewport && mapRef.current) {
-      const map = mapRef.current.getMap();
-      map.jumpTo({
-        center: [Number(longitude), Number(latitude)],
-        zoom: Number(zoom),
-      });
       setViewport({
-        latitude: Number(latitude),
-        longitude: Number(longitude),
-        zoom: Number(zoom),
+        latitude: lat,
+        longitude: lng,
+        zoom: z,
       });
+
+      if (!initialized) {
+        const map = mapRef.current.getMap();
+        map.jumpTo({
+          center: [lng, lat],
+          zoom: z,
+        });
+        setInitialized(true);
+      }
     }
-  }, [latitude, longitude, zoom]);
+  }, [initialized, latitude, longitude, zoom]);
 
   const handleParkingSearch = async (
     restrictTags: { key: string; tag: string }[]

--- a/src/types/MapProps.ts
+++ b/src/types/MapProps.ts
@@ -1,6 +1,7 @@
 import { ViewportProps } from "@/types/ViewportProps";
 import { LngLatBounds } from "mapbox-gl";
 import { FeatureCollection } from "geojson";
+import { MapRef } from "react-map-gl";
 
 export interface MapProps {
   parkingLots: FeatureCollection;
@@ -13,5 +14,5 @@ export interface MapProps {
   setBounds: (bounds: LngLatBounds) => void;
   viewport: ViewportProps;
   setViewport: (viewport: ViewportProps) => void;
-  mapRef: React.RefObject<any>;
+  mapRef: React.RefObject<MapRef>;
 }


### PR DESCRIPTION
The `map.jumpTo` method in the use effect overrides user input when trying to drag the map twice in quick succession. Making sure it only tries to move the map to the URL params on initial load fixes this

Also added `readOnly` to the dropdown to prevent console warnings because the checkbox is controlled through the state rather than through normal HTML